### PR TITLE
Fixes issue #23

### DIFF
--- a/framework/camera.js
+++ b/framework/camera.js
@@ -10,67 +10,74 @@ var Permissions = require('T/permissions');
 /**
  * Call showCamera or openPhotoGallery using same options
  * @private
- * @param  {String}   method 	Must be one of showCamera or openPhotoGallery
- * @param  {Object}   opt 		Options passed to `Ti.Media.FUNC`
- * @param  {Function} callback 	Success callback
+ * @param  {String}   method    Must be one of showCamera or openPhotoGallery
+ * @param  {Object}   opt       Options passed to `Ti.Media.FUNC`
+ * @param  {Function} callback  Success callback
  */
-function getPhoto(method, opt, callback){
-	Permissions.requestCameraPermissions(function() {
-		Ti.Media[method](_.extend({}, opt, {
-			mediaTypes: [ Ti.Media.MEDIA_TYPE_PHOTO ],
-			saveToPhotoGallery: (method === 'showCamera'),
-			success: callback,
-			cancel: function(e) { Ti.API.warn('Camera: Cancelled', e); },
-			error: function(err) {
-				Ti.API.error('Camera: Error', err);
-				Util.errorAlert(L('unexpected_error', 'Unexpected error'));
-			}
-		}));
-	}, function(err) {
-		Ti.API.error('Camera: Error', err);
-		Util.errorAlert(L('error_camera_permissions', 'Missing camera permissions'));
-	});
+function getPhoto(method, opt, callback) {
+    Permissions.requestCameraPermissions(function() {
+        opt = _.extend({}, opt, {
+            mediaTypes: [ Ti.Media.MEDIA_TYPE_PHOTO ],
+            saveToPhotoGallery: (method === 'showCamera'),
+            success: callback,
+            cancel: function(e) { Ti.API.warn('Camera: Cancelled', e); },
+            error: function(err) {
+                Ti.API.error('Camera: Error', err);
+                Util.errorAlert(L('unexpected_error', 'Unexpected error'));
+            }
+        });
+
+        // for some reason, when we try to call those methods dynamically
+        // (Ti.Media[methodName]() in special), Titanium will throw an error.
+        switch (method) {
+            case 'showCamera':       Ti.Media.showCamera(opt); break;
+            case 'openPhotoGallery': Ti.Media.openPhotoGallery(opt); break;
+        }
+    }, function(err) {
+        Ti.API.error('Camera: Error', err);
+        Util.errorAlert(L('error_camera_permissions', 'Missing camera permissions'));
+    });
 }
 
 /**
  * Open the Camera to take a photo
  *
- * @param  {Object}   opt 			Options passed to `Ti.Media.showCamera`
- * @param  {Function} callback  	Success callback
+ * @param  {Object}   opt           Options passed to `Ti.Media.showCamera`
+ * @param  {Function} callback      Success callback
  */
 exports.takePhoto = function(opt, callback) {
-	getPhoto('showCamera', opt, callback);
+    getPhoto('showCamera', opt, callback);
 };
 
 /**
  * Open the Gallery to chooose a photo
  *
- * @param  {Object}   opt 			Options passed to `Ti.Media.showCamera`
- * @param  {Function} callback  	Success callback
+ * @param  {Object}   opt           Options passed to `Ti.Media.showCamera`
+ * @param  {Function} callback      Success callback
  */
 exports.choosePhoto = function(opt, callback) {
-	getPhoto('openPhotoGallery', opt, callback);
+    getPhoto('openPhotoGallery', opt, callback);
 };
 
 /**
  * Display an option dialog to prompt the user to take a photo with the camera or select a photo from the gallery
  *
- * @param  {Object}   opt 			Options passed to `Ti.Media.showCamera`
- * @param  {Function} callback  	Success callback
+ * @param  {Object}   opt           Options passed to `Ti.Media.showCamera`
+ * @param  {Function} callback      Success callback
  */
-exports.selectPhoto = function(opt, callback){
-	Dialog.option(L('select_photo_source'), [
-	{
-		title: L('take_photo', 'Take photo'),
-		callback: function(){ exports.takePhoto(opt, callback); }
-	},
-	{
-		title: L('choose_existing_photo', 'Choose existing photo'),
-		callback: function(){ exports.choosePhoto(opt, callback); }
-	},
-	{
-		title: L('cancel'),
-		cancel: true
-	}
-	]);
+exports.selectPhoto = function(opt, callback) {
+    Dialog.option(L('select_photo_source'), [
+        {
+            title: L('take_photo', 'Take photo'),
+            callback: function() { exports.takePhoto(opt, callback); }
+        },
+        {
+            title: L('choose_existing_photo', 'Choose existing photo'),
+            callback: function() { exports.choosePhoto(opt, callback); }
+        },
+        {
+            title: L('cancel'),
+            cancel: true
+        }
+    ]);
 };

--- a/framework/camera.js
+++ b/framework/camera.js
@@ -15,28 +15,28 @@ var Permissions = require('T/permissions');
  * @param  {Function} callback  Success callback
  */
 function getPhoto(method, opt, callback) {
-    Permissions.requestCameraPermissions(function() {
-        opt = _.extend({}, opt, {
-            mediaTypes: [ Ti.Media.MEDIA_TYPE_PHOTO ],
-            saveToPhotoGallery: (method === 'showCamera'),
-            success: callback,
-            cancel: function(e) { Ti.API.warn('Camera: Cancelled', e); },
-            error: function(err) {
-                Ti.API.error('Camera: Error', err);
-                Util.errorAlert(L('unexpected_error', 'Unexpected error'));
-            }
-        });
+	Permissions.requestCameraPermissions(function() {
+		opt = _.extend({}, opt, {
+			mediaTypes: [ Ti.Media.MEDIA_TYPE_PHOTO ],
+			saveToPhotoGallery: (method === 'showCamera'),
+			success: callback,
+			cancel: function(e) { Ti.API.warn('Camera: Cancelled', e); },
+			error: function(err) {
+				Ti.API.error('Camera: Error', err);
+				Util.errorAlert(L('unexpected_error', 'Unexpected error'));
+			}
+		});
 
-        // for some reason, when we try to call those methods dynamically
-        // (Ti.Media[methodName]() in special), Titanium will throw an error.
-        switch (method) {
-            case 'showCamera':       Ti.Media.showCamera(opt); break;
-            case 'openPhotoGallery': Ti.Media.openPhotoGallery(opt); break;
-        }
-    }, function(err) {
-        Ti.API.error('Camera: Error', err);
-        Util.errorAlert(L('error_camera_permissions', 'Missing camera permissions'));
-    });
+		// for some reason, when we try to call those methods dynamically
+		// (Ti.Media[methodName]() in special), Titanium will throw an error.
+		switch (method) {
+			case 'showCamera':       Ti.Media.showCamera(opt); break;
+			case 'openPhotoGallery': Ti.Media.openPhotoGallery(opt); break;
+		}
+	}, function(err) {
+		Ti.API.error('Camera: Error', err);
+		Util.errorAlert(L('error_camera_permissions', 'Missing camera permissions'));
+	});
 }
 
 /**
@@ -46,7 +46,7 @@ function getPhoto(method, opt, callback) {
  * @param  {Function} callback      Success callback
  */
 exports.takePhoto = function(opt, callback) {
-    getPhoto('showCamera', opt, callback);
+	getPhoto('showCamera', opt, callback);
 };
 
 /**
@@ -56,7 +56,7 @@ exports.takePhoto = function(opt, callback) {
  * @param  {Function} callback      Success callback
  */
 exports.choosePhoto = function(opt, callback) {
-    getPhoto('openPhotoGallery', opt, callback);
+	getPhoto('openPhotoGallery', opt, callback);
 };
 
 /**
@@ -66,18 +66,18 @@ exports.choosePhoto = function(opt, callback) {
  * @param  {Function} callback      Success callback
  */
 exports.selectPhoto = function(opt, callback) {
-    Dialog.option(L('select_photo_source'), [
-        {
-            title: L('take_photo', 'Take photo'),
-            callback: function() { exports.takePhoto(opt, callback); }
-        },
-        {
-            title: L('choose_existing_photo', 'Choose existing photo'),
-            callback: function() { exports.choosePhoto(opt, callback); }
-        },
-        {
-            title: L('cancel'),
-            cancel: true
-        }
-    ]);
+	Dialog.option(L('select_photo_source'), [
+		{
+			title: L('take_photo', 'Take photo'),
+			callback: function() { exports.takePhoto(opt, callback); }
+		},
+		{
+			title: L('choose_existing_photo', 'Choose existing photo'),
+			callback: function() { exports.choosePhoto(opt, callback); }
+		},
+		{
+			title: L('cancel'),
+			cancel: true
+		}
+	]);
 };

--- a/framework/permissions.js
+++ b/framework/permissions.js
@@ -7,41 +7,68 @@
  * @property config
  */
 exports.config = _.extend({
-	// Placeholder for future configurations
+    // Placeholder for future configurations
 }, Alloy.CFG.T ? Alloy.CFG.permissions : {});
 
 var PERMISSIONS_TYPES = [
-{ name: 'Calendar', proxy: 'Calendar'},
-{ name: 'Camera', proxy: 'Media'},
-{ name: 'Contacts', proxy: 'Contacts'},
-{ name: 'Location', proxy: 'Geolocation'},
-{ name: 'Storage', proxy: 'Filesystem'}
+    { name: 'Calendar', proxy: 'Calendar'},
+    { name: 'Camera', proxy: 'Media'},
+    { name: 'Contacts', proxy: 'Contacts'},
+    { name: 'Location', proxy: 'Geolocation'},
+    { name: 'Storage', proxy: 'Filesystem'}
 ];
 
 PERMISSIONS_TYPES.forEach(function(type) {
-	exports['request' + type.name + 'Permissions'] = function(success, error) {
-		success = _.isFunction(success) ? success : Alloy.Globals.noop;
-		error = _.isFunction(error) ? error : Alloy.Globals.noop;
+    exports['request' + type.name + 'Permissions'] = function(success, error) {
+        success = _.isFunction(success) ? success : Alloy.Globals.noop;
+        error = _.isFunction(error) ? error : Alloy.Globals.noop;
 
-		var has 	= Ti[type.proxy]['has' + type.name + 'Permissions'];
-		var request = Ti[type.proxy]['request' + type.name + 'Permissions'];
+        // for some reason, when we try to call those methods dynamically
+        // (Ti.Media[methodName]() in special), Titanium will throw an error.
+        var has, request;
+        switch (type.name) {
+            case 'Calendar':
+                has     = Ti.Calendar.hasCalendarPermissions;
+                request = Ti.Calendar.requestCalendarPermissions;
+                break;
 
-		if (!_.isFunction(has) || !_.isFunction(request)) {
-			Ti.API.debug("Either of the functions [Ti." + type.proxy + ".has" + type.name + "Permissions(), Ti." + type.proxy + ".request" + type.name + "Permissions()] is missing");
-			return success();
-		}
+            case 'Camera':
+                has     = Ti.Media.hasCameraPermissions;
+                request = Ti.Media.requestCameraPermissions;
+                break;
 
-		if (has() !== true) {
-			request(function(res) {
-				if (res.success === true) {
-					success();
-				} else {
-					Ti.API.error('Permissions: Error while requesting ' + type.name + ' permissions:', res.error);
-					error({ message: L('error_' + type.name.toLowerCase() + '_permissions', 'Missing ' + type.name.toLowerCase() + ' permissions') });
-				}
-			});
-		} else {
-			success();
-		}
-	};
+            case 'Contacts':
+                has     = Ti.Contacts.hasContactsPermissions;
+                request = Ti.Contacts.requestContactsPermissions;
+                break;
+
+            case 'Location':
+                has     = Ti.Geolocation.hasLocationPermissions;
+                request = Ti.Geolocation.requestLocationPermissions;
+                break;
+
+            case 'Storage':
+                has     = Ti.Filesystem.hasStoragePermissions;
+                request = Ti.Filesystem.requestStoragePermissions;
+                break;
+        }
+
+        if (!_.isFunction(has) || !_.isFunction(request)) {
+            Ti.API.debug('Either of the functions [Ti.' + type.proxy + '.has' + type.name + 'Permissions(), Ti.' + type.proxy + '.request' + type.name + 'Permissions()] is missing');
+            return success();
+        }
+
+        if (has() !== true) {
+            request(function(res) {
+                if (res.success === true) {
+                    success();
+                } else {
+                    Ti.API.error('Permissions: Error while requesting ' + type.name + ' permissions:', res.error);
+                    error({ message: L('error_' + type.name.toLowerCase() + '_permissions', 'Missing ' + type.name.toLowerCase() + ' permissions') });
+                }
+            });
+        } else {
+            success();
+        }
+    };
 });

--- a/framework/permissions.js
+++ b/framework/permissions.js
@@ -7,68 +7,68 @@
  * @property config
  */
 exports.config = _.extend({
-    // Placeholder for future configurations
+	// Placeholder for future configurations
 }, Alloy.CFG.T ? Alloy.CFG.permissions : {});
 
 var PERMISSIONS_TYPES = [
-    { name: 'Calendar', proxy: 'Calendar'},
-    { name: 'Camera', proxy: 'Media'},
-    { name: 'Contacts', proxy: 'Contacts'},
-    { name: 'Location', proxy: 'Geolocation'},
-    { name: 'Storage', proxy: 'Filesystem'}
+	{ name: 'Calendar', proxy: 'Calendar'},
+	{ name: 'Camera', proxy: 'Media'},
+	{ name: 'Contacts', proxy: 'Contacts'},
+	{ name: 'Location', proxy: 'Geolocation'},
+	{ name: 'Storage', proxy: 'Filesystem'}
 ];
 
 PERMISSIONS_TYPES.forEach(function(type) {
-    exports['request' + type.name + 'Permissions'] = function(success, error) {
-        success = _.isFunction(success) ? success : Alloy.Globals.noop;
-        error = _.isFunction(error) ? error : Alloy.Globals.noop;
+	exports['request' + type.name + 'Permissions'] = function(success, error) {
+		success = _.isFunction(success) ? success : Alloy.Globals.noop;
+		error = _.isFunction(error) ? error : Alloy.Globals.noop;
 
-        // for some reason, when we try to call those methods dynamically
-        // (Ti.Media[methodName]() in special), Titanium will throw an error.
-        var has, request;
-        switch (type.name) {
-            case 'Calendar':
-                has     = Ti.Calendar.hasCalendarPermissions;
-                request = Ti.Calendar.requestCalendarPermissions;
-                break;
+		// for some reason, when we try to call those methods dynamically
+		// (Ti.Media[methodName]() in special), Titanium will throw an error.
+		var has, request;
+		switch (type.name) {
+			case 'Calendar':
+				has     = Ti.Calendar.hasCalendarPermissions;
+				request = Ti.Calendar.requestCalendarPermissions;
+				break;
 
-            case 'Camera':
-                has     = Ti.Media.hasCameraPermissions;
-                request = Ti.Media.requestCameraPermissions;
-                break;
+			case 'Camera':
+				has     = Ti.Media.hasCameraPermissions;
+				request = Ti.Media.requestCameraPermissions;
+				break;
 
-            case 'Contacts':
-                has     = Ti.Contacts.hasContactsPermissions;
-                request = Ti.Contacts.requestContactsPermissions;
-                break;
+			case 'Contacts':
+				has     = Ti.Contacts.hasContactsPermissions;
+				request = Ti.Contacts.requestContactsPermissions;
+				break;
 
-            case 'Location':
-                has     = Ti.Geolocation.hasLocationPermissions;
-                request = Ti.Geolocation.requestLocationPermissions;
-                break;
+			case 'Location':
+				has     = Ti.Geolocation.hasLocationPermissions;
+				request = Ti.Geolocation.requestLocationPermissions;
+				break;
 
-            case 'Storage':
-                has     = Ti.Filesystem.hasStoragePermissions;
-                request = Ti.Filesystem.requestStoragePermissions;
-                break;
-        }
+			case 'Storage':
+				has     = Ti.Filesystem.hasStoragePermissions;
+				request = Ti.Filesystem.requestStoragePermissions;
+				break;
+		}
 
-        if (!_.isFunction(has) || !_.isFunction(request)) {
-            Ti.API.debug('Either of the functions [Ti.' + type.proxy + '.has' + type.name + 'Permissions(), Ti.' + type.proxy + '.request' + type.name + 'Permissions()] is missing');
-            return success();
-        }
+		if (!_.isFunction(has) || !_.isFunction(request)) {
+			Ti.API.debug('Either of the functions [Ti.' + type.proxy + '.has' + type.name + 'Permissions(), Ti.' + type.proxy + '.request' + type.name + 'Permissions()] is missing');
+			return success();
+		}
 
-        if (has() !== true) {
-            request(function(res) {
-                if (res.success === true) {
-                    success();
-                } else {
-                    Ti.API.error('Permissions: Error while requesting ' + type.name + ' permissions:', res.error);
-                    error({ message: L('error_' + type.name.toLowerCase() + '_permissions', 'Missing ' + type.name.toLowerCase() + ' permissions') });
-                }
-            });
-        } else {
-            success();
-        }
-    };
+		if (has() !== true) {
+			request(function(res) {
+				if (res.success === true) {
+					success();
+				} else {
+					Ti.API.error('Permissions: Error while requesting ' + type.name + ' permissions:', res.error);
+					error({ message: L('error_' + type.name.toLowerCase() + '_permissions', 'Missing ' + type.name.toLowerCase() + ' permissions') });
+				}
+			});
+		} else {
+			success();
+		}
+	};
 });


### PR DESCRIPTION
Titanium throws an error when using dynamic requests for it's namespaces and methods on an iOS device as target.

The solution in this PR is a little ugly (switch/case), but it works.

----

Tested using the Ti SDK 6.0.0.GA.