### PR TITLE
Fixed a bug in T/HTTP when using SSL Pinning on Android

### DIFF
--- a/framework/http.js
+++ b/framework/http.js
@@ -141,13 +141,16 @@ HTTPRequest.prototype.toString = function() {
 };
 
 HTTPRequest.prototype._getResponseInfo = function() {
-	if (this.client == null || this.client.readyState <= 1) {
+	if (this.client == null || this.client.readyState < 1) {
 		throw new Error(MODULE_NAME + ': Client is null or not ready');
 	}
 
-	var headers = {
-		ContentType: this.client.getResponseHeader('Content-Type'),
-	};
+	var headers = {};
+	try {
+		headers.ContentType = this.client.getResponseHeader('Content-Type');
+	} catch(err) {
+		Ti.API.warn(MODULE_NAME + ': Error while getting Content-Type header: ' + err);
+	}
 
 	var info = {
 		format: 'blob',


### PR DESCRIPTION
The HTTPClient has a readyState == Ti.Network.HTTPClient.OPENED when the SSL Pinning fails. Also, the getResponseHeader call throws an error when invoked. This happens only on Android.
This fix is needed to maintain parity between platforms and return the correct error from HTTPS.