### PR TITLE
XMLParser: Fix bug when checking text content while cascading attributes

### DIFF
--- a/framework/xmlparser.js
+++ b/framework/xmlparser.js
@@ -197,7 +197,7 @@ function parse(xml, opts) {
 	}
 
 	function cascadingAttributes(e, element) {
-		if (e.text == "") {
+		if (e.text.replace(/^\s+|\s+$/g, '') == "") {
 			tempAttributes = concatAttributes(tempAttributes, e.attributes);
 		} else {
 			var start = currentLabel.text.length - e.text.length, length = e.text.length;


### PR DESCRIPTION
This solves a bug when using tags with just whitespace or newlines before the rest of the content.