### PR TITLE
Added HTTP hooks

### DIFF
--- a/framework/http.js
+++ b/framework/http.js
@@ -537,6 +537,8 @@ exports.resetCookies = function() {
  * @param {Function} [opt.success] 			The success callback
  * @param {Function} [opt.error] 			The error callback
  * @param {String} [opt.format] 				Override the format for that request (like `json`)
+ * @param {(Boolean|Array)} [opt.suppressFilters]	Prevent calling some or all of the filters added previously
+ * @param {(Boolean|Array)} [opt.suppressHooks]		Prevent calling some or all of the hooks added previously
  * @return {HTTP.Request}
  */
 function send(opt) {


### PR DESCRIPTION
The HTTP hooks work similarly to the filters system we already have.
A hook is a function that can be added or removed to HTTP calls by using `HTTP.addHook()` and `HTTP.removeHook()` respectively.
At each HTTP call completion, all of the hook functions are invoked with the result of the call as their only parameter. The developer can inhibit one or more of the hooks for a single call by using the parameter `suppressHooks` of `HTTP.send()`