### PR TITLE
Added Auth.resetUser() method

### DIFF
--- a/framework/auth.js
+++ b/framework/auth.js
@@ -515,6 +515,13 @@ exports.getUser = function(){
 };
 
 /**
+ * Reset current User model
+ */
+exports.resetUser = function(){
+	currentUser = null;
+};
+
+/**
  * Check if the user is logged in
  * @return {Boolean}
  */


### PR DESCRIPTION
Since `Auth.isLoggedIn()` checks wether the user model is not null, we can use `Auth.resetUser()` to "trick" the app into thinking that the user is not logged in anymore. This may be useful when the server closes the current user's session.