### PR TITLE
Removed "/" prefix from the controller's name in Flow.startup()

### DIFF
--- a/framework/flow.js
+++ b/framework/flow.js
@@ -164,7 +164,7 @@ exports.startup = function(controller, nav, win, controllerName, controllerArgs)
 	// Reset variables
 	windowsStack = [];
 
-	exports.setCurrentWindow(win, '/' + controllerName);
+	exports.setCurrentWindow(win, controllerName);
 	exports.setCurrentController(controller, controllerName, controllerArgs);
 	exports.setNavigationController(nav, true);
 };


### PR DESCRIPTION
We should remove that "/" prefix, to maintain parity with the `Flow.open()` and `Flow.openDirect()` methods. One may want to identify a controller with a name that is not prefixed by a slash, especially when tracking screen views through Google Analytics.