### PR TITLE
Auth: Avoid storing data at login when the "remember" option is false

### DIFF
--- a/framework/auth.js
+++ b/framework/auth.js
@@ -177,7 +177,9 @@ function fetchUserModel(opt, dataFromServer) {
 				cache: false,
 			},
 			success: function() {
-				Prop.setObject('auth.me', user.toJSON());
+				if (opt.remember) {
+					Prop.setObject('auth.me', user.toJSON());
+				}
 				resolve(user);
 			},
 			error: function(model, err) {
@@ -574,7 +576,9 @@ exports.login = function(opt) {
 	})
 
 	.then(function() {
-		Prop.setString('auth.driver', opt.driver);
+		if (opt.remember) {
+			Prop.setString('auth.driver', opt.driver);
+		}
 	})
 
 	.then(function() {


### PR DESCRIPTION
I've added a couple of checks in the login flow, to avoid storing data in the Ti.App.Properties when the `remember` option is set to false.