### PR TITLE
Using DELETE FROM table instead of TRUNCATE TABLE table

### DIFF
--- a/framework/cache/sqlite.js
+++ b/framework/cache/sqlite.js
@@ -41,9 +41,9 @@ exports.get = function(hash) {
  */
 exports.set = function(hash, value, ttl) {
 	var DB = getDatabase();
-	DB.run('INSERT OR REPLACE INTO ' + TABLE + ' (hash, expire, value) VALUES (?, ?, ?)', 
+	DB.run('INSERT OR REPLACE INTO ' + TABLE + ' (hash, expire, value) VALUES (?, ?, ?)',
 		hash,
-		Util.fromNow(ttl || 0), 
+		Util.fromNow(ttl || 0),
 		value
 	);
 };
@@ -63,7 +63,7 @@ exports.remove = function(hash) {
  */
 exports.purge = function() {
 	var DB = getDatabase();
-	DB.run('TRUNCATE TABLE ' + TABLE);
+	DB.run('DELETE FROM ' + TABLE);
 };
 
 /**

--- a/framework/sqlite.js
+++ b/framework/sqlite.js
@@ -308,7 +308,7 @@ SQLite.prototype.getExequery = function() {
 
 		case 'truncate':
 		return [
-			'TRUNCATE TABLE [' + this.query.table + ']'
+			'DELETE FROM [' + this.query.table + ']'
 		];
 
 		case 'insert':


### PR DESCRIPTION
SQLite has no "TRUNCATE TABLE" statement! See: https://www.techonthenet.com/sqlite/truncate.php

> SQLite does not have an explicit TRUNCATE TABLE command like other databases. Instead, it has added a TRUNCATE optimizer to the DELETE statement. To truncate a table in SQLite, you just need to execute a DELETE statement without a WHERE clause. The TRUNCATE optimizer handles the rest.