### PR TITLE
Remove "Google+" share option

### DIFF
--- a/framework/sharer.js
+++ b/framework/sharer.js
@@ -225,22 +225,6 @@ exports.email = exports.mail = function(args) {
 
 
 /**
- * Share on Google Plus
- * @param {Object} args
- */
-exports.googleplus = function(args) {
-	args = parseArgs(args);
-	GA.social('googleplus', 'share', args.url);
-
-	Ti.Platform.openURL('https://plus.google.com/share' + Util.buildQuery({
-		url: args.url
-	}));
-
-	return true;
-};
-
-
-/**
  * Share via Whatsapp
  * @param {Object} args
  */


### PR DESCRIPTION
Google has planned to shut down Google+ [on April 2 of this year](https://support.google.com/plus/answer/9195133?hl).

We should remove references to the service from Trimethyl.